### PR TITLE
swap/2 method is now called swapm/2 in keyd v2.4.2

### DIFF
--- a/keyd/default.conf
+++ b/keyd/default.conf
@@ -30,7 +30,7 @@ space = M-/
 # As soon as tab is pressed (but not yet released), we switch to the
 # "app_switch_state" overlay where we can handle Meta-Backtick differently.
 # Also, send a 'M-tab' key tap before entering app_switch_sate.
-tab = swap(app_switch_state, M-tab)
+tab = swapm(app_switch_state, M-tab)
 
 # Meta-Backtick: Switch to next window in the application group
 # - M-` is the default binding for 'switch-group' in gnome


### PR DESCRIPTION
This config produces a parse exception upon lauch of keyd v2.4.2
The reason:  keyd switched to hungarion notation. Thus swap/2 method needs to be renamed to swapm/2.